### PR TITLE
Fix settings api duplicating settings

### DIFF
--- a/internal/settings/settings_service.go
+++ b/internal/settings/settings_service.go
@@ -54,10 +54,10 @@ func (s *settingsService) GetSettings(ctx context.Context) (result types.MediaSe
 		for _, v := range nodeSettings.FileTypes {
 			fileTypeMapping[v] = ""
 		}
+	}
 
-		for k := range fileTypeMapping {
-			result.FileTypes = append(result.FileTypes, k)
-		}
+	for k := range fileTypeMapping {
+		result.FileTypes = append(result.FileTypes, k)
 	}
 
 	return


### PR DESCRIPTION
* **Fixed** issue where for each node the settings for filetypes was being put in the end result