### PR TITLE
Node media syncing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/egfanboy/mediapire-manager
 go 1.18
 
 require (
-	github.com/egfanboy/mediapire-common v0.0.0-20250305011245-327751234eec
+	github.com/egfanboy/mediapire-common v0.0.0-20250309025123-c43f48171275
 	github.com/egfanboy/mediapire-media-host v0.0.1-alpha.0.20250304014513-89b42671a16f
 	github.com/gorilla/mux v1.8.0
 	github.com/hashicorp/consul/api v1.15.3

--- a/go.sum
+++ b/go.sum
@@ -26,8 +26,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/disintegration/imaging v1.6.2/go.mod h1:44/5580QXChDfwIclfc/PCwrr44amcmDAg8hxG0Ewe4=
-github.com/egfanboy/mediapire-common v0.0.0-20250305011245-327751234eec h1:Hebom2i93RcOa4EBsA9XekGHXy7D7vEPHckwTDDGuuk=
-github.com/egfanboy/mediapire-common v0.0.0-20250305011245-327751234eec/go.mod h1:PfxxoHTUvFmiaEvmipwuReMmo8jQqe9mhHtWODuL7OI=
+github.com/egfanboy/mediapire-common v0.0.0-20250309025123-c43f48171275 h1:DmVEwXS/9W+on2mSxwb+hQL/r2Haa4NsSsepAFyYU+o=
+github.com/egfanboy/mediapire-common v0.0.0-20250309025123-c43f48171275/go.mod h1:PfxxoHTUvFmiaEvmipwuReMmo8jQqe9mhHtWODuL7OI=
 github.com/egfanboy/mediapire-media-host v0.0.1-alpha.0.20250304014513-89b42671a16f h1:/g2tF9o+IVWhUqof6b5MdAUEGTiI3qR1IsNvIITAXrw=
 github.com/egfanboy/mediapire-media-host v0.0.1-alpha.0.20250304014513-89b42671a16f/go.mod h1:ve7zmygXi/qoSerHmiE5BacQT5ZM8D46Qcd4SsEXh4Y=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=

--- a/internal/consul/watch.go
+++ b/internal/consul/watch.go
@@ -1,0 +1,32 @@
+package consul
+
+import (
+	"github.com/hashicorp/consul/api"
+	"github.com/rs/zerolog/log"
+)
+
+func WatchService(serviceName string, serviceRemoved chan<- struct{}) {
+	client, err := GetClient()
+	if err != nil {
+		return
+	}
+
+	var lastIndex uint64
+	for {
+		// do not only return healthy services, we do not want to treat a disconnected service as it being removed
+		services, meta, err := client.Health().Service(serviceName, "", false, &api.QueryOptions{
+			WaitIndex: lastIndex, // Long polling
+		})
+		if err != nil {
+			log.Err(err).Msgf("Failed to query health for service %s from consul.", serviceName)
+			continue
+		}
+
+		lastIndex = meta.LastIndex
+
+		if len(services) == 0 {
+			serviceRemoved <- struct{}{}
+			return
+		}
+	}
+}

--- a/internal/media/media-controller.go
+++ b/internal/media/media-controller.go
@@ -40,10 +40,18 @@ func (c mediaController) handleGetAll() router.RouteBuilder {
 		AddQueryParam(router.QueryParam{Name: queryParamMediaType, Required: false}).
 		AddQueryParam(router.QueryParam{Name: queryParamNodeId, Required: false}).
 		SetHandler(func(request *http.Request, p router.RouteParams) (interface{}, error) {
-			mediaType := strings.Split(p.Params[queryParamMediaType], ",")
-			nodeIds := strings.Split(p.Params[queryParamNodeId], ",")
+			nodeIds := make([]string, 0)
+			mediaTypes := make([]string, 0)
 
-			return c.service.GetMedia(request.Context(), mediaType, nodeIds)
+			if mediaTypeQuery, ok := p.Params[queryParamMediaType]; ok {
+				mediaTypes = append(mediaTypes, strings.Split(mediaTypeQuery, ",")...)
+			}
+
+			if nodeIdQuery, ok := p.Params[queryParamNodeId]; ok {
+				nodeIds = append(nodeIds, strings.Split(nodeIdQuery, ",")...)
+			}
+
+			return c.service.GetMedia(request.Context(), mediaTypes, nodeIds)
 		})
 }
 

--- a/internal/media/media_repo.go
+++ b/internal/media/media_repo.go
@@ -2,15 +2,32 @@ package media
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/egfanboy/mediapire-manager/internal/utils"
 	"github.com/egfanboy/mediapire-manager/pkg/types"
 )
 
+type mediaRepo interface {
+	GetMedia(ctx context.Context, filter getMediaFilter) ([]types.MediaItem, error)
+	SaveItems(ctx context.Context, items []types.MediaItem) error
+	DeleteMany(ctx context.Context, filter deleteManyFilter) error
+}
+
 type excludeFilter struct {
 	FieldName string
-	Value     interface{}
+	Values    []any
+}
+
+func newExcludeFilter[T comparable](fieldName string, typedValues []T) *excludeFilter {
+	values := make([]any, len(typedValues))
+
+	for i, v := range typedValues {
+		values[i] = v
+	}
+
+	return &excludeFilter{FieldName: fieldName, Values: values}
 }
 
 type getMediaFilter struct {
@@ -20,9 +37,36 @@ type getMediaFilter struct {
 	Exclude    *excludeFilter
 }
 
-type mediaRepo interface {
-	GetMedia(ctx context.Context, filter getMediaFilter) ([]types.MediaItem, error)
-	SaveItems(ctx context.Context, items []types.MediaItem) error
+func (f getMediaFilter) IsEmpty() bool {
+	if f.Id != nil {
+		return false
+	}
+
+	if len(f.NodeIds) > 0 {
+		return false
+	}
+
+	if len(f.MediaTypes) > 0 {
+		return false
+	}
+
+	if f.Exclude != nil {
+		return false
+	}
+
+	return true
+}
+
+type deleteManyFilter struct {
+	NodeId *string
+}
+
+func (f deleteManyFilter) IsEmpty() bool {
+	if f.NodeId != nil {
+		return false
+	}
+
+	return true
 }
 
 type inMemoryRepo struct {
@@ -38,6 +82,10 @@ func (r *inMemoryRepo) GetMedia(ctx context.Context, filter getMediaFilter) ([]t
 
 	r.mu.RLock()
 	defer r.mu.RUnlock()
+
+	if filter.IsEmpty() {
+		return r.mediaItems, nil
+	}
 
 	for _, item := range r.mediaItems {
 		if filter.Id != nil && item.Id == *filter.Id {
@@ -68,7 +116,16 @@ func (r *inMemoryRepo) GetMedia(ctx context.Context, filter getMediaFilter) ([]t
 				return nil, err
 			}
 
-			if jsonItem[filter.Exclude.FieldName] != filter.Exclude.Value {
+			matchesValue := false
+			for _, excludedValue := range filter.Exclude.Values {
+				if jsonItem[filter.Exclude.FieldName] == excludedValue {
+					matchesValue = true
+
+				}
+
+			}
+
+			if !matchesValue {
 				result = append(result, item)
 			}
 
@@ -79,10 +136,31 @@ func (r *inMemoryRepo) GetMedia(ctx context.Context, filter getMediaFilter) ([]t
 }
 
 func (r *inMemoryRepo) SaveItems(ctx context.Context, items []types.MediaItem) error {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
 	r.mediaItems = items
+
+	return nil
+}
+
+func (r *inMemoryRepo) DeleteMany(ctx context.Context, filter deleteManyFilter) error {
+	if filter.IsEmpty() {
+		return fmt.Errorf("cannot delete many without a filter")
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	result := make([]types.MediaItem, 0)
+
+	for _, item := range r.mediaItems {
+		if filter.NodeId != nil && item.NodeId != *filter.NodeId {
+			result = append(result, item)
+		}
+	}
+
+	r.mediaItems = result
 
 	return nil
 }

--- a/internal/media/media_sync.go
+++ b/internal/media/media_sync.go
@@ -4,16 +4,21 @@ import (
 	"context"
 	"sort"
 
+	"github.com/egfanboy/mediapire-manager/internal/node"
 	"github.com/egfanboy/mediapire-manager/pkg/types"
+	"github.com/rs/zerolog/log"
 )
 
 type MediaSync interface {
 	HandleNewNode(ctx context.Context, nodeId string) error
+	SyncFromAllNodes(ctx context.Context) error
+	HandleRemovedNode(ctx context.Context, nodeId string) error
 }
 
 type syncService struct {
 	mediaService MediaApi
 	repo         mediaRepo
+	nodeService  node.NodeApi
 }
 
 func (s *syncService) HandleNewNode(ctx context.Context, nodeId string) error {
@@ -22,30 +27,14 @@ func (s *syncService) HandleNewNode(ctx context.Context, nodeId string) error {
 		return err
 	}
 
-	otherMedia, err := s.repo.GetMedia(ctx, getMediaFilter{Exclude: &excludeFilter{FieldName: "nodeId", Value: nodeId}})
+	otherMedia, err := s.repo.GetMedia(ctx, getMediaFilter{Exclude: &excludeFilter{FieldName: "nodeId", Values: []interface{}{nodeId}}})
 	if err != nil {
 		return err
 	}
 
-	mediaByExtension := make(map[string][]types.MediaItem)
+	media = append(media, otherMedia...)
 
-	for _, m := range media {
-		mediaByExtension[m.Extension] = append(mediaByExtension[m.Extension], m)
-	}
-
-	for _, m := range otherMedia {
-		mediaByExtension[m.Extension] = append(mediaByExtension[m.Extension], m)
-	}
-
-	sortedItems := make([]types.MediaItem, len(otherMedia)+len(media))
-
-	for _, v := range mediaByExtension {
-		sort.SliceStable(v, func(i, j int) bool {
-			return v[i].Name < v[j].Name
-		})
-
-		sortedItems = append(sortedItems, v...)
-	}
+	sortedItems := sortMediaByExtension(media)
 
 	err = s.repo.SaveItems(ctx, sortedItems)
 	if err != nil {
@@ -55,14 +44,76 @@ func (s *syncService) HandleNewNode(ctx context.Context, nodeId string) error {
 	return nil
 }
 
+func (s *syncService) SyncFromAllNodes(ctx context.Context) error {
+	nodes, err := s.nodeService.GetAllNodes(ctx)
+	if err != nil {
+		return err
+	}
+
+	nodesToFetch := make([]string, 0)
+
+	for _, node := range nodes {
+		if node.IsUp {
+			nodesToFetch = append(nodesToFetch, node.Id)
+		} else {
+			log.Debug().Msgf("node %s is not up and will be skipped when fetching media", node.Id)
+		}
+	}
+
+	media, err := s.mediaService.InternalGetAllMediaFromNodes(ctx, nodesToFetch)
+	if err != nil {
+		return err
+	}
+
+	sortedItems := sortMediaByExtension(media)
+
+	err = s.repo.SaveItems(ctx, sortedItems)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *syncService) HandleRemovedNode(ctx context.Context, nodeId string) error {
+	return s.repo.DeleteMany(ctx, deleteManyFilter{NodeId: &nodeId})
+}
+
+func sortMediaByExtension(media []types.MediaItem) []types.MediaItem {
+	mediaByExtension := make(map[string][]types.MediaItem)
+
+	for _, m := range media {
+		mediaByExtension[m.Extension] = append(mediaByExtension[m.Extension], m)
+	}
+
+	sortedItems := make([]types.MediaItem, 0)
+
+	for _, v := range mediaByExtension {
+		sort.SliceStable(v, func(i, j int) bool {
+			return v[i].Name < v[j].Name
+		})
+
+		sortedItems = append(sortedItems, v...)
+	}
+
+	return sortedItems
+}
+
 func NewMediaSyncService(ctx context.Context) (MediaSync, error) {
 	mediaService, err := NewMediaService()
 	if err != nil {
 		return nil, err
 	}
+
 	repo, err := newMediaRepo(ctx)
 	if err != nil {
 		return nil, err
 	}
-	return &syncService{mediaService: mediaService, repo: repo}, nil
+
+	nodeService, err := node.NewNodeService()
+	if err != nil {
+		return nil, err
+	}
+
+	return &syncService{mediaService: mediaService, repo: repo, nodeService: nodeService}, nil
 }

--- a/internal/node/connectivity/async.go
+++ b/internal/node/connectivity/async.go
@@ -1,10 +1,11 @@
-package media
+package connectivity
 
 import (
 	"context"
 	"encoding/json"
 
 	"github.com/egfanboy/mediapire-common/messaging"
+	"github.com/egfanboy/mediapire-manager/internal/media"
 	"github.com/egfanboy/mediapire-manager/internal/rabbitmq"
 	"github.com/rabbitmq/amqp091-go"
 	"github.com/rs/zerolog/log"
@@ -18,19 +19,21 @@ func handleNodeReadyMessage(ctx context.Context, msg amqp091.Delivery) {
 		return
 	}
 
-	log.Info().Msgf("Node %s is ready", nodeMsg.NodeId)
+	log.Info().Msgf("Node %s is ready", nodeMsg.Id)
 
-	syncService, err := NewMediaSyncService(ctx)
+	syncService, err := media.NewMediaSyncService(ctx)
 	if err != nil {
 		return
 	}
 
-	err = syncService.HandleNewNode(ctx, nodeMsg.NodeId)
+	// start goroutine watchers for this node
+	WatchNode(nodeMsg.Name, nodeMsg.Id)
+
+	err = syncService.HandleNewNode(ctx, nodeMsg.Id)
 	if err != nil {
-		log.Err(err).Msgf("Could not sync media from node %s", nodeMsg.NodeId)
+		log.Err(err).Msgf("Could not sync media from node %s", nodeMsg.Id)
 		return
 	}
-
 }
 
 func init() {

--- a/internal/node/connectivity/watcher.go
+++ b/internal/node/connectivity/watcher.go
@@ -1,0 +1,59 @@
+package connectivity
+
+import (
+	"context"
+	"sync"
+
+	"github.com/egfanboy/mediapire-manager/internal/consul"
+	"github.com/egfanboy/mediapire-manager/internal/media"
+	"github.com/rs/zerolog/log"
+)
+
+type nodeConnectivityWatcher struct {
+	mu    sync.RWMutex
+	nodes map[string]bool
+}
+
+func (w *nodeConnectivityWatcher) WatchNode(nodeName, nodeId string) {
+	serviceRemoved := make(chan struct{})
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if _, ok := w.nodes[nodeId]; ok {
+		log.Debug().Msgf("Node %s already being watched.", nodeId)
+	} else {
+		log.Debug().Msgf("Registering watcher for node %s.", nodeId)
+		w.nodes[nodeId] = true
+		go consul.WatchService(nodeName, serviceRemoved)
+		go w.handleServiceRemoval(nodeId, serviceRemoved)
+	}
+
+}
+
+func (w *nodeConnectivityWatcher) handleServiceRemoval(nodeId string, serviceRemoved <-chan struct{}) {
+	<-serviceRemoved
+
+	log.Info().Msgf("Node %s was removed", nodeId)
+	ctx := context.Background()
+	syncService, err := media.NewMediaSyncService(ctx)
+	if err != nil {
+		return
+	}
+
+	err = syncService.HandleRemovedNode(ctx, nodeId)
+	if err != nil {
+		log.Err(err).Msgf("Could not remove media from node %s", nodeId)
+	}
+
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+
+	delete(w.nodes, nodeId)
+}
+
+var watcher = &nodeConnectivityWatcher{mu: sync.RWMutex{}, nodes: make(map[string]bool)}
+
+func WatchNode(nodeName, nodeId string) {
+	watcher.WatchNode(nodeName, nodeId)
+}

--- a/internal/node/node_controller.go
+++ b/internal/node/node_controller.go
@@ -13,7 +13,7 @@ const basePath = "/nodes"
 
 type nodeController struct {
 	builders []func() router.RouteBuilder
-	service  nodeApi
+	service  NodeApi
 }
 
 func (c nodeController) GetApis() (routes []router.RouteBuilder) {

--- a/internal/node/node_service.go
+++ b/internal/node/node_service.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/egfanboy/mediapire-manager/internal/app"
+
 	"github.com/rs/zerolog/log"
 )
 
@@ -16,7 +17,7 @@ func MakeNodeHash(h string) string {
 	return fmt.Sprintf("mediahost:%s", h)
 }
 
-type nodeApi interface {
+type NodeApi interface {
 	GetAllNodes(ctx context.Context) ([]NodeConfig, error)
 }
 
@@ -38,8 +39,7 @@ func (s *nodeService) GetAllNodes(ctx context.Context) ([]NodeConfig, error) {
 	return nodes, nil
 }
 
-func NewNodeService() (nodeApi, error) {
-
+func NewNodeService() (NodeApi, error) {
 	repo, err := NewNodeRepo()
 
 	if err != nil {


### PR DESCRIPTION
* **Added** consul watching which will watch a service and if it gets removed from consul the media for that node is deleted
* **Added** logic to sync media from all nodes on start up
* **Added** logic to setup watchers for existing nodes on start up
* **Added** logic to setup watcher when a new node message is received
* **Fixed** an issue where no media was being returned since splitting on an empty query param gave a slice of len 1 with an empty string
* **Removed** the exception when fetching media by node id that required the node to be up
* **Changed** the `exception` filter to allow filtering on multiple values
* **Added** check for empty filter query to the media db to just return all records if filter has no values set
* **Added** logic when getting all media from the db to filter out records from down nodes so they stay in the db but do not get returned to the user
* **Added** exception to the get media API if the user requests media for a specific node and that node is down