### PR TITLE
Fixes to enable edit of a mp3 item

### DIFF
--- a/internal/media/media-service.go
+++ b/internal/media/media-service.go
@@ -245,28 +245,38 @@ func (s *mediaService) InternalUpdateMedia(ctx context.Context, changeSetId stri
 
 		builder := media_update.GetBuilder(mediaItem)
 
-		if change.Change.Title != "" {
-			builder.Title(change.Change.Title)
+		if change.Change.Name != "" {
+			builder.Name(change.Change.Name)
 		}
 
 		if change.Change.Artist != "" {
-			builder.Title(change.Change.Artist)
+			builder.Artist(change.Change.Artist)
 		}
 
 		if change.Change.Album != "" {
-			builder.Title(change.Change.Album)
+			builder.Album(change.Change.Album)
 		}
 
 		if change.Change.Comment != "" {
-			builder.Title(change.Change.Comment)
+			builder.Comment(change.Change.Comment)
 		}
 
 		if change.Change.Genre != "" {
-			builder.Title(change.Change.Genre)
+			builder.Genre(change.Change.Genre)
 		}
 
-		if change.Change.TrackNumber != 0 {
-			builder.TrackNumber(change.Change.TrackNumber)
+		if change.Change.TrackIndex != 0 {
+			trackFormat := fmt.Sprintf("%d", change.Change.TrackIndex)
+			if change.Change.TrackOf != 0 {
+				// ffmpeg expects a format of 2/10 to represent track 2 of 10
+				trackFormat = fmt.Sprintf("%s/%d", trackFormat, change.Change.TrackOf)
+				builder.Track(trackFormat)
+			}
+		}
+
+		// if no track of set the track to be empty
+		if change.Change.TrackOf == 0 {
+			builder.Track("")
 		}
 
 		if change.Change.Art != "" {

--- a/internal/media/update/media_updater.go
+++ b/internal/media/update/media_updater.go
@@ -84,12 +84,12 @@ type UpdateBuilder interface {
 type BaseUpdater interface {
 	UpdateBuilder
 
-	Title(title string) BaseUpdater
+	Name(name string) BaseUpdater
 	Album(album string) BaseUpdater
 	Artist(artist string) BaseUpdater
 	Comment(comment string) BaseUpdater
 	Genre(genre string) BaseUpdater
-	TrackNumber(trackNumber int) BaseUpdater
+	Track(track string) BaseUpdater
 	Art(imagePath string) BaseUpdater
 }
 
@@ -107,8 +107,8 @@ type baseMediaUpdater struct {
 	getInputStreamsImpl func(self *baseMediaUpdater) []*ffmpeg_go.Stream
 }
 
-func (u *baseMediaUpdater) Title(title string) BaseUpdater {
-	u.metadata = append(u.metadata, fmt.Sprintf(`title=%s`, title))
+func (u *baseMediaUpdater) Name(name string) BaseUpdater {
+	u.metadata = append(u.metadata, fmt.Sprintf(`title=%s`, name))
 
 	return u
 }
@@ -137,11 +137,11 @@ func (u *baseMediaUpdater) Genre(genre string) BaseUpdater {
 	return u
 }
 
-func (u *baseMediaUpdater) TrackNumber(trackNumber int) BaseUpdater {
-	if u.media.Extension == "mp3" {
-		log.Warn().Msgf("Item %s does not support updating the track number", u.media.Id)
+func (u *baseMediaUpdater) Track(track string) BaseUpdater {
+	if u.media.Extension != "mp3" {
+		log.Warn().Msgf("Item %s does not support updating the track index", u.media.Id)
 	} else {
-		u.metadata = append(u.metadata, fmt.Sprintf("track=%d", trackNumber))
+		u.metadata = append(u.metadata, fmt.Sprintf("track=%s", track))
 	}
 
 	return u

--- a/pkg/types/changeset.go
+++ b/pkg/types/changeset.go
@@ -3,13 +3,14 @@ package types
 import "time"
 
 type MediaItemChange struct {
-	Title       string `json:"title"`
-	Artist      string `json:"artist"`
-	Album       string `json:"album"`
-	Comment     string `json:"comment"`
-	Genre       string `json:"genre"`
-	TrackNumber int    `json:"trackNumber"`
-	Art         string `json:"art"`
+	Name       string `json:"name"`
+	Artist     string `json:"artist"`
+	Album      string `json:"album"`
+	Comment    string `json:"comment"`
+	Genre      string `json:"genre"`
+	TrackIndex int    `json:"trackIndex"`
+	TrackOf    int    `json:"trackOf"`
+	Art        string `json:"art"`
 }
 
 type Changeset struct {


### PR DESCRIPTION
* **Fixed** the update of a media item
* **Renamed** `title` to `name`
* **Added** the ability to properly set the trackIndex/trackOf