### PR TITLE
Need to move getAllById before handleGetAll

### DIFF
--- a/internal/media/media-controller.go
+++ b/internal/media/media-controller.go
@@ -165,12 +165,13 @@ func initController() (mediaController, error) {
 
 	c.builders = append(
 		c.builders,
+		// getAllById needs to go before handleGetAll since gorilla mux uses whatever matches first
+		c.getAllById,
 		c.handleGetAll,
 		c.StreamMedia,
 		c.DownloadMedia,
 		c.DeleteMedia,
 		c.handleGetArt,
-		c.getAllById,
 	)
 
 	return c, nil


### PR DESCRIPTION
Due to how the mux router works need and since we made pagination optional the getAll route was being matched before the getAllById. Therefore, getAllById will have to come first and if the one required query param is present that will be matched and if not it will fall through and match the getAll.