### PR TITLE
Add media sync after a successful update

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/egfanboy/mediapire-manager/internal/consul"
 	"github.com/egfanboy/mediapire-manager/internal/mongo"
 	"github.com/egfanboy/mediapire-manager/internal/rabbitmq"
+	"github.com/egfanboy/mediapire-manager/internal/websocket"
 
 	// APIs - start
 

--- a/internal/changeset/async.go
+++ b/internal/changeset/async.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 
 	"github.com/egfanboy/mediapire-common/messaging"
+	"github.com/egfanboy/mediapire-manager/internal/media"
 	"github.com/egfanboy/mediapire-manager/internal/rabbitmq"
 	"github.com/rabbitmq/amqp091-go"
 	"github.com/rs/zerolog/log"
@@ -74,6 +75,20 @@ func (u updatedMessageHandler) HandleMessage(ctx context.Context, msg amqp091.De
 		if err != nil {
 			log.Err(err).Msgf("failed to update changeset %s to %s", updateMsg.ChangesetId, StatusComplete)
 			return
+		}
+
+		if changeset.IsDone() {
+			syncService, err := media.NewMediaSyncService(ctx)
+			if err != nil {
+				log.Err(err).Msgf("failed to initialize media sync service for changeset %s", updateMsg.ChangesetId)
+				return
+			}
+
+			err = syncService.SyncNodeMedia(ctx, updateMsg.NodeId)
+			if err != nil {
+				log.Err(err).Msgf("failed to refresh media for node %s after changeset %s", updateMsg.NodeId, updateMsg.ChangesetId)
+				return
+			}
 		}
 	}
 

--- a/internal/changeset/changeset_model.go
+++ b/internal/changeset/changeset_model.go
@@ -47,6 +47,7 @@ func (c *Changeset) ToApiResponse() types.ChangesetItem {
 	}
 }
 
+// For now there is always just one output but this should be changed if we support multiple
 func (c *Changeset) IsDone() bool {
 	var isDone bool
 	for _, v := range c.Outputs {

--- a/internal/media/media_sync.go
+++ b/internal/media/media_sync.go
@@ -10,7 +10,7 @@ import (
 )
 
 type MediaSync interface {
-	HandleNewNode(ctx context.Context, nodeId string) error
+	SyncNodeMedia(ctx context.Context, nodeId string) error
 	SyncFromAllNodes(ctx context.Context) error
 	HandleRemovedNode(ctx context.Context, nodeId string) error
 }
@@ -21,7 +21,7 @@ type syncService struct {
 	nodeService  node.NodeApi
 }
 
-func (s *syncService) HandleNewNode(ctx context.Context, nodeId string) error {
+func (s *syncService) SyncNodeMedia(ctx context.Context, nodeId string) error {
 	media, err := s.mediaService.GetMediaByNodeId(ctx, []string{}, nodeId)
 	if err != nil {
 		return err

--- a/internal/node/connectivity/async.go
+++ b/internal/node/connectivity/async.go
@@ -29,7 +29,7 @@ func handleNodeReadyMessage(ctx context.Context, msg amqp091.Delivery) {
 	// start goroutine watchers for this node
 	WatchNode(nodeMsg.Name, nodeMsg.Id)
 
-	err = syncService.HandleNewNode(ctx, nodeMsg.Id)
+	err = syncService.SyncNodeMedia(ctx, nodeMsg.Id)
 	if err != nil {
 		log.Err(err).Msgf("Could not sync media from node %s", nodeMsg.Id)
 		return
@@ -47,8 +47,8 @@ func handleNodeMediaUpdateMessage(ctx context.Context, msg amqp091.Delivery) {
 		return
 	}
 
-	// HandleNewNode syncs media from a node.
-	err = syncService.HandleNewNode(ctx, data.Id)
+	// SyncNodeMedia syncs media from a node.
+	err = syncService.SyncNodeMedia(ctx, data.Id)
 	if err != nil {
 		log.Err(err).Msgf("Could not sync media from node %s", data.Id)
 		return


### PR DESCRIPTION
* **Added** a force sync of media for a node after processing an update
* **Renamed** `HandleNewNode` since it was misleading.