### PR TITLE
Added playback session mechanism

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -20,6 +20,7 @@ import (
 	_ "github.com/egfanboy/mediapire-manager/internal/health"
 	"github.com/egfanboy/mediapire-manager/internal/media"
 	"github.com/egfanboy/mediapire-manager/internal/node"
+	_ "github.com/egfanboy/mediapire-manager/internal/playback"
 	_ "github.com/egfanboy/mediapire-manager/internal/settings"
 	_ "github.com/egfanboy/mediapire-manager/internal/transfer"
 

--- a/internal/playback/playback_controller.go
+++ b/internal/playback/playback_controller.go
@@ -1,0 +1,103 @@
+package playback
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/egfanboy/mediapire-common/router"
+	"github.com/egfanboy/mediapire-manager/internal/app"
+	"github.com/egfanboy/mediapire-manager/pkg/types"
+	"github.com/rs/zerolog/log"
+)
+
+const basePath = "/playback/session"
+
+type playbackController struct {
+	builders []func() router.RouteBuilder
+	service  PlaybackApi
+}
+
+func (c playbackController) GetApis() (routes []router.RouteBuilder) {
+	for _, b := range c.builders {
+		routes = append(routes, b())
+	}
+
+	return
+}
+
+func (c playbackController) getSession() router.RouteBuilder {
+	return router.NewV1RouteBuilder().
+		SetMethod(http.MethodOptions, http.MethodGet).
+		SetPath(basePath).
+		SetReturnCode(http.StatusOK).
+		SetHandler(func(request *http.Request, p router.RouteParams) (interface{}, error) {
+			return c.service.GetSession(request.Context())
+		})
+}
+
+func (c playbackController) setQueue() router.RouteBuilder {
+	return router.NewV1RouteBuilder().
+		SetMethod(http.MethodOptions, http.MethodPost).
+		SetPath(basePath + "/queue").
+		SetReturnCode(http.StatusOK).
+		SetHandler(func(request *http.Request, p router.RouteParams) (interface{}, error) {
+			var body types.PlaybackSetQueueRequest
+			if err := p.PopulateBody(&body); err != nil {
+				return nil, err
+			}
+
+			return c.service.SetQueue(request.Context(), body)
+		})
+}
+
+func (c playbackController) startFromMedia() router.RouteBuilder {
+	return router.NewV1RouteBuilder().
+		SetMethod(http.MethodOptions, http.MethodPost).
+		SetPath(basePath + "/start").
+		SetReturnCode(http.StatusOK).
+		SetHandler(func(request *http.Request, p router.RouteParams) (interface{}, error) {
+			var body types.PlaybackStartRequest
+			if err := p.PopulateBody(&body); err != nil {
+				return nil, err
+			}
+
+			return c.service.StartFromMedia(request.Context(), body)
+		})
+}
+
+func (c playbackController) postCommand() router.RouteBuilder {
+	return router.NewV1RouteBuilder().
+		SetMethod(http.MethodOptions, http.MethodPost).
+		SetPath(basePath + "/commands").
+		SetReturnCode(http.StatusOK).
+		SetHandler(func(request *http.Request, p router.RouteParams) (interface{}, error) {
+			var body types.PlaybackCommandRequest
+			if err := p.PopulateBody(&body); err != nil {
+				return nil, err
+			}
+
+			return c.service.ApplyCommand(request.Context(), body)
+		})
+}
+
+func initController() (playbackController, error) {
+	service, err := newPlaybackService(context.Background())
+	if err != nil {
+		return playbackController{}, err
+	}
+
+	controller := playbackController{service: service}
+	controller.builders = append(controller.builders, controller.getSession, controller.setQueue, controller.startFromMedia, controller.postCommand)
+
+	return controller, nil
+}
+
+func init() {
+	controller, err := initController()
+	if err != nil {
+		log.Error().Err(err).Msg("failed to instantiate playback controller")
+		return
+	}
+
+	app.GetApp().ControllerRegistry.Register(controller)
+}

--- a/internal/playback/playback_model.go
+++ b/internal/playback/playback_model.go
@@ -1,0 +1,63 @@
+package playback
+
+import (
+	"time"
+
+	"github.com/egfanboy/mediapire-manager/pkg/types"
+)
+
+type repeatMode string
+
+const (
+	repeatModeOff repeatMode = "off"
+	repeatModeOne repeatMode = "one"
+	repeatModeAll repeatMode = "all"
+)
+
+type playbackSession struct {
+	Id                    string                   `bson:"_id"`
+	Queue                 []types.MediaItemMapping `bson:"queue"`
+	PlayOrder             []int                    `bson:"playOrder"`
+	CurrentPlayOrderIndex int                      `bson:"currentPlayOrderIndex"`
+	ShuffleEnabled        bool                     `bson:"shuffleEnabled"`
+	ShuffleSeed           int64                    `bson:"shuffleSeed"`
+	RepeatMode            repeatMode               `bson:"repeatMode"`
+	CreatedAt             time.Time                `bson:"createdAt"`
+	UpdatedAt             time.Time                `bson:"updatedAt"`
+}
+
+func newPlaybackSession(id string, now time.Time) *playbackSession {
+	return &playbackSession{
+		Id:                    id,
+		Queue:                 make([]types.MediaItemMapping, 0),
+		PlayOrder:             make([]int, 0),
+		CurrentPlayOrderIndex: -1,
+		ShuffleEnabled:        false,
+		ShuffleSeed:           0,
+		RepeatMode:            repeatModeOff,
+		CreatedAt:             now,
+		UpdatedAt:             now,
+	}
+}
+
+func (s *playbackSession) toApiState() types.PlaybackSessionState {
+	state := types.PlaybackSessionState{
+		Queue:                 s.Queue,
+		PlayOrder:             s.PlayOrder,
+		CurrentPlayOrderIndex: s.CurrentPlayOrderIndex,
+		ShuffleEnabled:        s.ShuffleEnabled,
+		RepeatMode:            string(s.RepeatMode),
+		UpdatedAt:             s.UpdatedAt,
+	}
+
+	if s.CurrentPlayOrderIndex >= 0 && s.CurrentPlayOrderIndex < len(s.PlayOrder) {
+		queueIndex := s.PlayOrder[s.CurrentPlayOrderIndex]
+		if queueIndex >= 0 && queueIndex < len(s.Queue) {
+			current := s.Queue[queueIndex]
+			state.CurrentItem = &current
+			state.CurrentQueueIndex = &queueIndex
+		}
+	}
+
+	return state
+}

--- a/internal/playback/playback_repo.go
+++ b/internal/playback/playback_repo.go
@@ -1,0 +1,71 @@
+package playback
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+)
+
+const (
+	sessionDocumentId  = "default"
+	sessionIdleTimeout = 60 * time.Minute
+)
+
+var errSessionNotFound = errors.New("playback session not found")
+
+type playbackRepository interface {
+	Get(ctx context.Context) (*playbackSession, error)
+	Create(ctx context.Context, session *playbackSession) error
+	Save(ctx context.Context, session *playbackSession) error
+}
+
+type repo struct {
+	mu        sync.RWMutex
+	session   *playbackSession
+	expiresAt time.Time
+}
+
+var playbackRepoInstance = &repo{}
+
+func (r *repo) Get(ctx context.Context) (*playbackSession, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	if r.session == nil || r.isExpired(time.Now()) {
+		return nil, errSessionNotFound
+	}
+
+	sessionCopy := *r.session
+	return &sessionCopy, nil
+}
+
+func (r *repo) Create(ctx context.Context, session *playbackSession) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	sessionCopy := *session
+	r.session = &sessionCopy
+	r.expiresAt = time.Now().Add(sessionIdleTimeout)
+
+	return nil
+}
+
+func (r *repo) Save(ctx context.Context, session *playbackSession) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	sessionCopy := *session
+	r.session = &sessionCopy
+	r.expiresAt = time.Now().Add(sessionIdleTimeout)
+
+	return nil
+}
+
+func (r *repo) isExpired(now time.Time) bool {
+	return !r.expiresAt.IsZero() && now.After(r.expiresAt)
+}
+
+func newPlaybackRepository(ctx context.Context) (playbackRepository, error) {
+	return playbackRepoInstance, nil
+}

--- a/internal/playback/playback_service.go
+++ b/internal/playback/playback_service.go
@@ -1,0 +1,459 @@
+package playback
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/egfanboy/mediapire-common/exceptions"
+	commonRouter "github.com/egfanboy/mediapire-common/router"
+	"github.com/egfanboy/mediapire-manager/internal/media"
+	"github.com/egfanboy/mediapire-manager/internal/websocket"
+	"github.com/egfanboy/mediapire-manager/pkg/types"
+)
+
+const (
+	commandNext            = "next"
+	commandPrevious        = "previous"
+	commandSetRepeat       = "set_repeat"
+	commandSetShuffle      = "set_shuffle"
+	commandSetCurrentIndex = "set_current_index"
+)
+
+type PlaybackApi interface {
+	GetSession(ctx context.Context) (types.PlaybackSessionState, error)
+	SetQueue(ctx context.Context, request types.PlaybackSetQueueRequest) (types.PlaybackSessionState, error)
+	StartFromMedia(ctx context.Context, request types.PlaybackStartRequest) (types.PlaybackSessionState, error)
+	ApplyCommand(ctx context.Context, request types.PlaybackCommandRequest) (types.PlaybackSessionState, error)
+}
+
+type playbackService struct {
+	repo         playbackRepository
+	mediaService media.MediaApi
+	nowFn        func() time.Time
+}
+
+func (s *playbackService) GetSession(ctx context.Context) (types.PlaybackSessionState, error) {
+	session, err := s.ensureSession(ctx)
+	if err != nil {
+		return types.PlaybackSessionState{}, err
+	}
+
+	return s.buildResponseState(ctx, session)
+}
+
+func (s *playbackService) SetQueue(ctx context.Context, request types.PlaybackSetQueueRequest) (types.PlaybackSessionState, error) {
+	session, err := s.ensureSession(ctx)
+	if err != nil {
+		return types.PlaybackSessionState{}, err
+	}
+
+	if err := s.validateQueueItems(ctx, request.Items); err != nil {
+		return types.PlaybackSessionState{}, err
+	}
+
+	now := s.nowFn()
+	if err := setQueue(session, request.Items, request.StartIndex, now.UnixNano()); err != nil {
+		return types.PlaybackSessionState{}, exceptions.NewBadRequestException(err)
+	}
+
+	saved, err := s.saveMutation(ctx, session, now)
+	if err != nil {
+		return types.PlaybackSessionState{}, err
+	}
+
+	state, err := s.buildResponseState(ctx, saved)
+	if err != nil {
+		return types.PlaybackSessionState{}, err
+	}
+	_ = websocket.SendPlaybackSessionUpdated(state)
+
+	return state, nil
+}
+
+func (s *playbackService) StartFromMedia(ctx context.Context, request types.PlaybackStartRequest) (types.PlaybackSessionState, error) {
+	session, err := s.ensureSession(ctx)
+	if err != nil {
+		return types.PlaybackSessionState{}, err
+	}
+
+	filtering := types.ApiFilteringParams{}
+	if request.SortBy != nil && strings.TrimSpace(*request.SortBy) != "" {
+		filtering, err = types.NewApiFilteringParams(commonRouter.RouteParams{Params: map[string]string{"sortBy": strings.TrimSpace(*request.SortBy)}})
+		if err != nil {
+			return types.PlaybackSessionState{}, err
+		}
+	}
+
+	mediaTypes := splitCommaSeparated(request.MediaType)
+	mediaIds := splitCommaSeparated(request.MediaIds)
+
+	items, err := s.getMediaForStart(ctx, mediaTypes, mediaIds, filtering)
+	if err != nil {
+		return types.PlaybackSessionState{}, err
+	}
+
+	if request.RepeatMode != nil {
+		mode := strings.TrimSpace(*request.RepeatMode)
+		switch mode {
+		case string(repeatModeOff):
+			session.RepeatMode = repeatModeOff
+		case string(repeatModeOne):
+			session.RepeatMode = repeatModeOne
+		case string(repeatModeAll):
+			session.RepeatMode = repeatModeAll
+		default:
+			return types.PlaybackSessionState{}, exceptions.NewBadRequestException(fmt.Errorf("invalid repeat mode %s", mode))
+		}
+	}
+
+	if request.ShuffleEnabled != nil {
+		session.ShuffleEnabled = *request.ShuffleEnabled
+	}
+
+	queue := make([]types.MediaItemMapping, 0, len(items))
+	for _, item := range items {
+		queue = append(queue, types.MediaItemMapping{NodeId: item.NodeId, MediaId: item.Id})
+	}
+
+	now := s.nowFn()
+	if err := setQueue(session, queue, request.StartIndex, now.UnixNano()); err != nil {
+		return types.PlaybackSessionState{}, exceptions.NewBadRequestException(err)
+	}
+
+	saved, err := s.saveMutation(ctx, session, now)
+	if err != nil {
+		return types.PlaybackSessionState{}, err
+	}
+
+	state, err := s.buildResponseState(ctx, saved)
+	if err != nil {
+		return types.PlaybackSessionState{}, err
+	}
+	_ = websocket.SendPlaybackSessionUpdated(state)
+
+	return state, nil
+}
+
+func (s *playbackService) ApplyCommand(ctx context.Context, request types.PlaybackCommandRequest) (types.PlaybackSessionState, error) {
+	session, err := s.ensureSession(ctx)
+	if err != nil {
+		return types.PlaybackSessionState{}, err
+	}
+
+	now := s.nowFn()
+	err = s.applyCommandMutation(ctx, session, request, now)
+	if err != nil {
+		return types.PlaybackSessionState{}, err
+	}
+
+	saved, err := s.saveMutation(ctx, session, now)
+	if err != nil {
+		return types.PlaybackSessionState{}, err
+	}
+
+	state, err := s.buildResponseState(ctx, saved)
+	if err != nil {
+		return types.PlaybackSessionState{}, err
+	}
+	_ = websocket.SendPlaybackSessionUpdated(state)
+
+	return state, nil
+}
+
+func (s *playbackService) navigate(
+	ctx context.Context,
+	session *playbackSession,
+	delta int,
+) error {
+	if len(session.PlayOrder) == 0 || session.CurrentPlayOrderIndex < 0 || session.CurrentPlayOrderIndex >= len(session.PlayOrder) {
+		return nil
+	}
+
+	previousPos := session.CurrentPlayOrderIndex
+	pos := previousPos
+
+	for checked := 0; checked < len(session.PlayOrder); checked++ {
+		nextPos := pos + delta
+		if nextPos < 0 || nextPos >= len(session.PlayOrder) {
+			if session.RepeatMode == repeatModeAll {
+				if delta > 0 {
+					nextPos = 0
+				} else {
+					nextPos = len(session.PlayOrder) - 1
+				}
+			} else {
+				break
+			}
+		}
+
+		pos = nextPos
+
+		exists, err := s.itemExistsAtOrderPos(ctx, session, pos)
+		if err != nil {
+			return err
+		}
+		if exists {
+			session.CurrentPlayOrderIndex = pos
+			return nil
+		}
+	}
+
+	existsAtPrevious, err := s.itemExistsAtOrderPos(ctx, session, previousPos)
+	if err != nil {
+		return err
+	}
+
+	if existsAtPrevious {
+		session.CurrentPlayOrderIndex = previousPos
+	} else {
+		session.CurrentPlayOrderIndex = -1
+	}
+
+	return nil
+}
+
+func (s *playbackService) itemExistsAtOrderPos(ctx context.Context, session *playbackSession, orderPos int) (bool, error) {
+	if orderPos < 0 || orderPos >= len(session.PlayOrder) {
+		return false, nil
+	}
+
+	queueIndex := session.PlayOrder[orderPos]
+	if queueIndex < 0 || queueIndex >= len(session.Queue) {
+		return false, nil
+	}
+
+	item := session.Queue[queueIndex]
+	mediaItems, err := s.mediaService.GetMedia(ctx, []string{}, []string{item.NodeId}, []string{item.MediaId})
+	if err != nil {
+		// Treat fetch errors as not-found for skip behavior.
+		return false, nil
+	}
+
+	return len(mediaItems) > 0, nil
+}
+
+func (s *playbackService) buildResponseState(ctx context.Context, session *playbackSession) (types.PlaybackSessionState, error) {
+	state := session.toApiState()
+
+	if state.CurrentItem == nil {
+		return state, nil
+	}
+
+	currentMedia, err := s.mediaService.GetMedia(
+		ctx,
+		[]string{},
+		[]string{state.CurrentItem.NodeId},
+		[]string{state.CurrentItem.MediaId},
+	)
+	if err != nil {
+		return types.PlaybackSessionState{}, err
+	}
+
+	if len(currentMedia) > 0 {
+		state.CurrentMedia = &currentMedia[0]
+	}
+
+	return state, nil
+}
+
+func (s *playbackService) getMediaForStart(
+	ctx context.Context,
+	mediaTypes []string,
+	mediaIds []string,
+	filtering types.ApiFilteringParams,
+) ([]types.MediaItem, error) {
+	if filtering.SortByField == nil {
+		return s.mediaService.GetMedia(ctx, mediaTypes, []string{}, mediaIds)
+	}
+
+	result, err := s.mediaService.GetMediaPaginated(ctx, mediaTypes, []string{}, filtering, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	mediaResponse, ok := result.(types.MediaResponse)
+	if !ok {
+		return nil, errors.New("unexpected media response type")
+	}
+
+	if len(mediaIds) == 0 {
+		return mediaResponse.Results, nil
+	}
+
+	allowedIds := make(map[string]struct{}, len(mediaIds))
+	for _, id := range mediaIds {
+		allowedIds[id] = struct{}{}
+	}
+
+	filtered := make([]types.MediaItem, 0, len(mediaResponse.Results))
+	for _, item := range mediaResponse.Results {
+		if _, ok := allowedIds[item.Id]; ok {
+			filtered = append(filtered, item)
+		}
+	}
+
+	return filtered, nil
+}
+
+func splitCommaSeparated(value *string) []string {
+	if value == nil {
+		return []string{}
+	}
+
+	trimmed := strings.TrimSpace(*value)
+	if trimmed == "" {
+		return []string{}
+	}
+
+	parts := strings.Split(trimmed, ",")
+	result := make([]string, 0, len(parts))
+	for _, part := range parts {
+		v := strings.TrimSpace(part)
+		if v != "" {
+			result = append(result, v)
+		}
+	}
+
+	return result
+}
+
+func (s *playbackService) saveMutation(ctx context.Context, session *playbackSession, now time.Time) (*playbackSession, error) {
+	session.UpdatedAt = now
+
+	if err := s.repo.Save(ctx, session); err != nil {
+		return nil, err
+	}
+
+	return session, nil
+}
+
+func (s *playbackService) ensureSession(ctx context.Context) (*playbackSession, error) {
+	session, err := s.repo.Get(ctx)
+	if err == nil {
+		// Extend idle lifetime on access so the session only expires when unused.
+		if saveErr := s.repo.Save(ctx, session); saveErr != nil {
+			return nil, saveErr
+		}
+		return session, nil
+	}
+
+	if !errors.Is(err, errSessionNotFound) {
+		return nil, err
+	}
+
+	now := s.nowFn()
+	newSession := newPlaybackSession(sessionDocumentId, now)
+	if err := s.repo.Create(ctx, newSession); err != nil {
+		return nil, err
+	}
+
+	return newSession, nil
+}
+
+func (s *playbackService) validateQueueItems(ctx context.Context, items []types.MediaItemMapping) error {
+	for _, item := range items {
+		found, err := s.mediaService.GetMedia(ctx, []string{}, []string{item.NodeId}, []string{item.MediaId})
+		if err != nil {
+			return err
+		}
+
+		if len(found) == 0 {
+			return exceptions.NewBadRequestException(
+				fmt.Errorf("media item %s on node %s does not exist", item.MediaId, item.NodeId),
+			)
+		}
+	}
+
+	return nil
+}
+
+func (s *playbackService) applyCommandMutation(
+	ctx context.Context,
+	session *playbackSession,
+	request types.PlaybackCommandRequest,
+	now time.Time,
+) error {
+	switch request.Command {
+	case commandNext:
+		return s.navigate(ctx, session, 1)
+	case commandPrevious:
+		return s.navigate(ctx, session, -1)
+	case commandSetRepeat:
+		if request.Payload.Mode == nil {
+			return exceptions.NewBadRequestException(errors.New("payload.mode is required for set_repeat"))
+		}
+
+		switch *request.Payload.Mode {
+		case string(repeatModeOff):
+			session.RepeatMode = repeatModeOff
+		case string(repeatModeOne):
+			session.RepeatMode = repeatModeOne
+		case string(repeatModeAll):
+			session.RepeatMode = repeatModeAll
+		default:
+			return exceptions.NewBadRequestException(fmt.Errorf("invalid repeat mode %s", *request.Payload.Mode))
+		}
+	case commandSetShuffle:
+		if request.Payload.Enabled == nil {
+			return exceptions.NewBadRequestException(errors.New("payload.enabled is required for set_shuffle"))
+		}
+
+		currentQueueIndex := -1
+		if session.CurrentPlayOrderIndex >= 0 && session.CurrentPlayOrderIndex < len(session.PlayOrder) {
+			currentQueueIndex = session.PlayOrder[session.CurrentPlayOrderIndex]
+		}
+
+		session.ShuffleEnabled = *request.Payload.Enabled
+		if len(session.Queue) > 0 {
+			session.ShuffleSeed = now.UnixNano()
+			session.PlayOrder = buildPlayOrder(len(session.Queue), session.ShuffleEnabled, session.ShuffleSeed)
+
+			if currentQueueIndex >= 0 {
+				if session.ShuffleEnabled {
+					orderPos, err := getOrderPosByQueueIndex(session.PlayOrder, currentQueueIndex)
+					if err != nil {
+						return exceptions.NewBadRequestException(err)
+					}
+					session.PlayOrder[0], session.PlayOrder[orderPos] = session.PlayOrder[orderPos], session.PlayOrder[0]
+					session.CurrentPlayOrderIndex = 0
+					return nil
+				}
+
+				newPos, err := getOrderPosByQueueIndex(session.PlayOrder, currentQueueIndex)
+				if err != nil {
+					return exceptions.NewBadRequestException(err)
+				}
+				session.CurrentPlayOrderIndex = newPos
+			}
+		}
+	case commandSetCurrentIndex:
+		if request.Payload.Index == nil {
+			return exceptions.NewBadRequestException(errors.New("payload.index is required for set_current_index"))
+		}
+
+		if err := setCurrentIndex(session, *request.Payload.Index); err != nil {
+			return exceptions.NewBadRequestException(err)
+		}
+	default:
+		return exceptions.NewBadRequestException(fmt.Errorf("unsupported command %s", request.Command))
+	}
+
+	return nil
+}
+
+func newPlaybackService(ctx context.Context) (PlaybackApi, error) {
+	repo, err := newPlaybackRepository(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	mediaService, err := media.NewMediaService()
+	if err != nil {
+		return nil, err
+	}
+
+	return &playbackService{repo: repo, mediaService: mediaService, nowFn: time.Now}, nil
+}

--- a/internal/playback/state_machine.go
+++ b/internal/playback/state_machine.go
@@ -1,0 +1,160 @@
+package playback
+
+import (
+	"errors"
+	"fmt"
+	"math/rand"
+
+	"github.com/egfanboy/mediapire-manager/pkg/types"
+)
+
+func buildPlayOrder(queueSize int, shuffleEnabled bool, seed int64) []int {
+	order := make([]int, queueSize)
+	for i := 0; i < queueSize; i++ {
+		order[i] = i
+	}
+
+	if !shuffleEnabled || queueSize <= 1 {
+		return order
+	}
+
+	r := rand.New(rand.NewSource(seed))
+	for i := queueSize - 1; i > 0; i-- {
+		j := r.Intn(i + 1)
+		order[i], order[j] = order[j], order[i]
+	}
+
+	return order
+}
+
+func getOrderPosByQueueIndex(playOrder []int, queueIndex int) (int, error) {
+	for i, idx := range playOrder {
+		if idx == queueIndex {
+			return i, nil
+		}
+	}
+
+	return -1, errors.New("queue index not found in play order")
+}
+
+func setQueue(session *playbackSession, items []types.MediaItemMapping, startIndex *int, shuffleSeed int64) error {
+	session.Queue = items
+
+	if len(items) == 0 {
+		session.PlayOrder = make([]int, 0)
+		session.CurrentPlayOrderIndex = -1
+		return nil
+	}
+
+	if startIndex != nil && (*startIndex < 0 || *startIndex >= len(items)) {
+		return fmt.Errorf("startIndex %d is out of bounds", *startIndex)
+	}
+
+	if session.ShuffleEnabled {
+		session.ShuffleSeed = shuffleSeed
+	}
+
+	session.PlayOrder = buildPlayOrder(len(items), session.ShuffleEnabled, session.ShuffleSeed)
+
+	if startIndex == nil && session.ShuffleEnabled {
+		session.CurrentPlayOrderIndex = 0
+		return nil
+	}
+
+	indexToUse := 0
+	if startIndex != nil {
+		indexToUse = *startIndex
+	}
+
+	orderPos, err := getOrderPosByQueueIndex(session.PlayOrder, indexToUse)
+	if err != nil {
+		return err
+	}
+
+	session.CurrentPlayOrderIndex = orderPos
+	return nil
+}
+
+func setCurrentIndex(session *playbackSession, index int) error {
+	if len(session.Queue) == 0 {
+		return errors.New("queue is empty")
+	}
+
+	if index < 0 || index >= len(session.Queue) {
+		return fmt.Errorf("index %d is out of bounds", index)
+	}
+
+	orderPos, err := getOrderPosByQueueIndex(session.PlayOrder, index)
+	if err != nil {
+		return err
+	}
+
+	session.CurrentPlayOrderIndex = orderPos
+	return nil
+}
+
+func next(session *playbackSession) {
+	if len(session.PlayOrder) == 0 {
+		session.CurrentPlayOrderIndex = -1
+		return
+	}
+
+	if session.RepeatMode == repeatModeOne {
+		if session.CurrentPlayOrderIndex < 0 {
+			session.CurrentPlayOrderIndex = 0
+		}
+		return
+	}
+
+	lastIndex := len(session.PlayOrder) - 1
+	if session.CurrentPlayOrderIndex < 0 {
+		session.CurrentPlayOrderIndex = 0
+		return
+	}
+
+	switch session.RepeatMode {
+	case repeatModeAll:
+		if session.CurrentPlayOrderIndex >= lastIndex {
+			session.CurrentPlayOrderIndex = 0
+			return
+		}
+		session.CurrentPlayOrderIndex++
+	default:
+		if session.CurrentPlayOrderIndex < lastIndex {
+			session.CurrentPlayOrderIndex++
+		}
+	}
+}
+
+func previous(session *playbackSession) {
+	if len(session.PlayOrder) == 0 {
+		session.CurrentPlayOrderIndex = -1
+		return
+	}
+
+	if session.RepeatMode == repeatModeOne {
+		if session.CurrentPlayOrderIndex < 0 {
+			session.CurrentPlayOrderIndex = 0
+		}
+		return
+	}
+
+	lastIndex := len(session.PlayOrder) - 1
+	if session.CurrentPlayOrderIndex < 0 {
+		session.CurrentPlayOrderIndex = lastIndex
+		return
+	}
+
+	switch session.RepeatMode {
+	case repeatModeAll:
+		if session.CurrentPlayOrderIndex == 0 {
+			session.CurrentPlayOrderIndex = lastIndex
+			return
+		}
+		session.CurrentPlayOrderIndex--
+	default:
+		if session.CurrentPlayOrderIndex > 0 {
+			session.CurrentPlayOrderIndex--
+		}
+	}
+}

--- a/internal/websocket/websocket.go
+++ b/internal/websocket/websocket.go
@@ -1,9 +1,11 @@
 package websocket
 
 import (
+	"encoding/json"
 	"net/http"
 	"strings"
 
+	"github.com/egfanboy/mediapire-manager/pkg/types"
 	"github.com/gorilla/mux"
 	"github.com/gorilla/websocket"
 )
@@ -11,7 +13,6 @@ import (
 var allowedOrigins = make(map[string]struct{})
 var allowAllOrigins = true
 
-// Upgrader to handle HTTP -> WS upgrade
 var upgrader = websocket.Upgrader{
 	CheckOrigin: checkOrigin,
 }
@@ -21,7 +22,6 @@ type Client struct {
 	send chan []byte
 }
 
-// Hub holds all connected clients
 type Hub struct {
 	clients    map[*Client]bool
 	register   chan *Client
@@ -29,7 +29,6 @@ type Hub struct {
 	broadcast  chan []byte
 }
 
-// Global hub instance
 var hub = Hub{
 	clients:    make(map[*Client]bool),
 	register:   make(chan *Client),
@@ -70,7 +69,6 @@ func (c *Client) readPump() {
 		if err != nil {
 			break
 		}
-		// We ignore client messages here, but you could handle them
 	}
 }
 
@@ -133,4 +131,23 @@ func RegisterWebSocketHandler(router *mux.Router, origins []string) {
 
 func SendMessage(msg []byte) {
 	hub.broadcast <- msg
+}
+
+type playbackSessionUpdatedEnvelope struct {
+	Type  string                     `json:"type"`
+	State types.PlaybackSessionState `json:"state"`
+}
+
+func SendPlaybackSessionUpdated(state types.PlaybackSessionState) error {
+	payload, err := json.Marshal(playbackSessionUpdatedEnvelope{
+		Type:  "playback.session.updated",
+		State: state,
+	})
+	if err != nil {
+		return err
+	}
+
+	SendMessage(payload)
+
+	return nil
 }

--- a/pkg/types/playback.go
+++ b/pkg/types/playback.go
@@ -1,0 +1,48 @@
+package types
+
+import "time"
+
+type RepeatMode string
+
+const (
+	RepeatModeOff RepeatMode = "off"
+	RepeatModeOne RepeatMode = "one"
+	RepeatModeAll RepeatMode = "all"
+)
+
+type PlaybackSessionState struct {
+	Queue                 []MediaItemMapping `json:"queue"`
+	PlayOrder             []int              `json:"playOrder"`
+	CurrentPlayOrderIndex int                `json:"currentPlayOrderIndex"`
+	CurrentItem           *MediaItemMapping  `json:"currentItem,omitempty"`
+	CurrentQueueIndex     *int               `json:"currentQueueIndex,omitempty"`
+	CurrentMedia          *MediaItem         `json:"currentMedia,omitempty"`
+	ShuffleEnabled        bool               `json:"shuffleEnabled"`
+	RepeatMode            string             `json:"repeatMode"`
+	UpdatedAt             time.Time          `json:"updatedAt"`
+}
+
+type PlaybackSetQueueRequest struct {
+	Items      []MediaItemMapping `json:"items"`
+	StartIndex *int               `json:"startIndex"`
+}
+
+type PlaybackStartRequest struct {
+	MediaType      *string `json:"mediaType,omitempty"`
+	MediaIds       *string `json:"mediaIds,omitempty"`
+	SortBy         *string `json:"sortBy,omitempty"`
+	StartIndex     *int    `json:"startIndex,omitempty"`
+	ShuffleEnabled *bool   `json:"shuffleEnabled,omitempty"`
+	RepeatMode     *string `json:"repeatMode,omitempty"`
+}
+
+type PlaybackCommandPayload struct {
+	Mode    *string `json:"mode,omitempty"`
+	Enabled *bool   `json:"enabled,omitempty"`
+	Index   *int    `json:"index,omitempty"`
+}
+
+type PlaybackCommandRequest struct {
+	Command string                 `json:"command"`
+	Payload PlaybackCommandPayload `json:"payload"`
+}


### PR DESCRIPTION
* **Added** a new backend playback domain to manage music session state server-side instead of keeping shuffle/repeat/navigation logic only in the UI.
* **Introduced** playback HTTP APIs to read session state, start playback from media filters, set an explicit queue, and issue playback commands.
* **Added** websocket playback events so clients receive backend session updates in real time.